### PR TITLE
fix bug that all router table item deleted

### DIFF
--- a/ARP/ARPDlg.cpp
+++ b/ARP/ARPDlg.cpp
@@ -556,10 +556,8 @@ void CARPDlg::AddRoutingTable(const int _index, CString ip1, CString ip2, CStrin
 
 void CARPDlg::OnBnClickedButtonDelRoutingTableEntry()
 {
-	int nListIndex = m_ListStaticRoutingTable.GetItemCount();
-
-
-	m_ListStaticRoutingTable.DeleteAllItems(); 
+	int nListIndex = m_ListStaticRoutingTable.GetSelectionMark();
+	m_ListStaticRoutingTable.DeleteItem(nListIndex);
 }
 
 


### PR DESCRIPTION
ARPDlg.cpp에서 `OnBnClickedButtonDelRoutingTableEntry` 함수가 모든 아이템을 지우도록 설정하고 있어서 아래와 같이 수정하였습니다.
현재 테스트해본 결과 잘 작동합니다.
확인 후 pull request 승인 해주세요.
```C++
void CARPDlg::OnBnClickedButtonDelRoutingTableEntry()
{
	int nListIndex = m_ListStaticRoutingTable.GetSelectionMark();
	m_ListStaticRoutingTable.DeleteItem(nListIndex);
}
```